### PR TITLE
solve cuda tensor issue

### DIFF
--- a/lib/loss/rpn_3d.py
+++ b/lib/loss/rpn_3d.py
@@ -122,7 +122,7 @@ class RPN_3D_loss(nn.Module):
         bbox_l3d_dn = bbox_l3d * self.bbox_stds[:, 9][0] + self.bbox_means[:, 9][0]
         bbox_ry3d_dn = bbox_ry3d * self.bbox_stds[:, 10][0] + self.bbox_means[:, 10][0]
 
-        src_anchors = self.anchors[rois[:, 4].type(torch.cuda.LongTensor), :]
+        src_anchors = self.anchors[rois[:, 4].type(torch.LongTensor), :]
         src_anchors = torch.tensor(src_anchors, requires_grad=False).type(torch.cuda.FloatTensor)
         if len(src_anchors.shape) == 1: src_anchors = src_anchors.unsqueeze(0)
 
@@ -193,7 +193,7 @@ class RPN_3D_loss(nn.Module):
                 bg_inds = np.flatnonzero(labels_bg)
                 ign_inds = np.flatnonzero(labels_ign)
 
-                transforms = torch.from_numpy(transforms).cuda()
+                transforms = torch.from_numpy(transforms)
 
                 labels[bind, fg_inds] = transforms[fg_inds, 4]
                 labels[bind, ign_inds] = IGN_FLAG
@@ -285,7 +285,7 @@ class RPN_3D_loss(nn.Module):
                     bbox_x3d_dn_fg = bbox_x3d_dn[bind, fg_inds]
                     bbox_y3d_dn_fg = bbox_y3d_dn[bind, fg_inds]
 
-                    src_anchors = self.anchors[rois[fg_inds, 4].type(torch.cuda.LongTensor), :]
+                    src_anchors = self.anchors[rois[fg_inds, 4].type(torch.LongTensor), :]
                     src_anchors = torch.tensor(src_anchors, requires_grad=False).type(torch.cuda.FloatTensor)
                     if len(src_anchors.shape) == 1: src_anchors = src_anchors.unsqueeze(0)
 


### PR DESCRIPTION
モデル読み込んで学習が始まったところでエラー

```
Traceback (most recent call last):
  File "scripts/train_rpn_3d.py", line 196, in <module>
    main(sys.argv[1:])
  File "scripts/train_rpn_3d.py", line 125, in main
    det_loss, det_stats = criterion_det(cls, prob, bbox_2d, bbox_3d, imobjs, feat_size)
  File " ... lib/python3.6/site-packages/torch/nn/modules/module.py", line 489, in __call__
    result = self.forward(*input, **kwargs)
  File " ... M3D-RPN/lib/loss/rpn_3d.py", line 125, in forward
    src_anchors = self.anchors[rois[:, 4].type(torch.cuda.LongTensor), :]
  File " ... lib/python3.6/site-packages/torch/tensor.py", line 450, in __array__
    return self.numpy()
TypeError: can't convert CUDA tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```

close 済みの issue で発見: https://github.com/garrickbrazil/M3D-RPN/issues/4

バージョンの違いにより起きるエラーの場所が違うそうで、cudaを数箇所外す。解決。

無事学習進む状態に。

```
iter: 250, acc (bg: 0.97, fg: 0.41, iou: 0.60), loss (bbox_3d: 2.3070, cls: 0.6679, iou: 0.5160), misc (ry: 1.40, z: 2.77), dt: 0.65, eta: 9.0h
iter: 500, acc (bg: 0.99, fg: 0.72, iou: 0.67), loss (bbox_3d: 1.5296, cls: 0.3313, iou: 0.4154), misc (ry: 1.22, z: 2.01), dt: 0.65, eta: 8.9h
iter: 750, acc (bg: 0.99, fg: 0.78, iou: 0.70), loss (bbox_3d: 1.4353, cls: 0.2692, iou: 0.3711), misc (ry: 1.20, z: 1.82), dt: 0.65, eta: 8.8h
iter: 1000, acc (bg: 0.99, fg: 0.84, iou: 0.72), loss (bbox_3d: 1.1279, cls: 0.2238, iou: 0.3321), misc (ry: 1.00, z: 1.48), dt: 0.65, eta: 8.8h
iter: 1250, acc (bg: 0.99, fg: 0.86, iou: 0.74), loss (bbox_3d: 1.1383, cls: 0.2007, iou: 0.3099), misc (ry: 0.95, z: 1.54), dt: 0.65, eta: 8.8h
```